### PR TITLE
Create .travis.yml for CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+sudo: false
+
+language: r
+r:
+  - oldrel
+  - release
+  - devel
+
+cache: packages
+
+before_install:
+  - cd ArboristBridgeR/Package/
+  - chmod u+x Rborist.CRAN.sh
+  - ./Rborist.CRAN.sh
+
+install:
+  - tar -xzvf Rborist_*.*-*.tar.gz
+  - Rscript -e 'install.packages("devtools")'
+  - Rscript -e 'devtools::install_deps("Rborist")'
+script:
+  - Rscript -e 'devtools::check("Rborist", manual = TRUE)'
+  
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+r_github_packages:
+  - jimhester/covr
+
+# This can be enabled if you want code coverage
+#after_success:
+#  - Rscript -e 'install.packages("covr"); covr::coveralls("Rborist")'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![CRAN](http://www.r-pkg.org/badges/version/Rborist)](https://cran.rstudio.com/web/packages/Rborist/index.html)
 [![Downloads](http://cranlogs.r-pkg.org/badges/Rborist?color=brightgreen)](http://www.r-pkg.org/pkg/Rborist)
 [![PyPI version](https://badge.fury.io/py/pyborist.svg)](https://pypi.python.org/pypi/pyborist/) 
+[![Travis-CI Build Status](https://travis-ci.org/suiji/Arborist.svg?branch=master)](https://travis-ci.org/suiji/Arborist)
 
 
 


### PR DESCRIPTION
Work on setting up continuous integration, as mentioned in issue #15 
I wrote this "blind" without testing, so it may fail the first couple builds and need some tweaking setting up Travis CI, but that's the point of CI after all :)

It's possible to do this without `devtools` as well, but since this is just on Github it won't impact the CRAN package dependencies.